### PR TITLE
fix(ooniauth-core): salt probe-id hash computation.

### DIFF
--- a/ooniauth-core/src/submit.rs
+++ b/ooniauth-core/src/submit.rs
@@ -57,14 +57,7 @@ fn digest_point(point: RistrettoPoint) -> [u8; 32] {
 }
 
 impl UserState {
-    #[instrument(skip(
-        self,
-        rng,
-        probe_cc,
-        probe_asn,
-        age_range,
-        measurement_count_range
-    ))]
+    #[instrument(skip(self, rng, probe_cc, probe_asn, age_range, measurement_count_range))]
     pub fn submit_request(
         &self,
         rng: &mut (impl RngCore + CryptoRng),

--- a/ooniauth-core/src/submit.rs
+++ b/ooniauth-core/src/submit.rs
@@ -10,6 +10,7 @@ use sha2::{Digest, Sha256, Sha512};
 use tracing::{debug, instrument, trace};
 
 const SESSION_ID: &[u8] = b"submit";
+const PROBE_ID_SALT: &[u8] = b"ooni.org/userauth/v1";
 
 muCMZProtocol!(submit<min_age_today, max_age, min_measurement_count,
         max_measurement_count, @DOMAIN, @NYM>,
@@ -46,7 +47,10 @@ impl SubmitRequest {
 }
 
 fn digest_point(point: RistrettoPoint) -> [u8; 32] {
-    let digest = Sha256::digest(point.compress().as_bytes());
+    let mut hasher = Sha256::new();
+    hasher.update(PROBE_ID_SALT);
+    hasher.update(point.compress().as_bytes());
+    let digest = hasher.finalize();
     let mut out = [0u8; 32];
     out.copy_from_slice(&digest);
     out
@@ -221,7 +225,7 @@ impl ServerState {
         let domain_str = format!("ooni.org/{}/{}", probe_cc, probe_asn);
         let DOMAIN = G::hash_from_bytes::<Sha512>(domain_str.as_bytes());
 
-        // The probe id is the same as the nym point.
+        // The probe id must be the salted hash of the nym point.
         // Otherwise, return an error.
         // We do not really care about the server returning early here,
         // a malicious probe should already have computed the probe ID from the

--- a/ooniauth-py/src/protocol.rs
+++ b/ooniauth-py/src/protocol.rs
@@ -4,10 +4,7 @@ use ooniauth_core::submit::submit;
 use ooniauth_core::update::*;
 use ooniauth_core::{self as ooni, PublicParameters, SecretKey};
 
-use pyo3::{
-    prelude::*,
-    types::PyString,
-};
+use pyo3::{prelude::*, types::PyString};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyfunction, gen_stub_pymethods};
 
 use crate::utils::{from_pystring, to_pystring};
@@ -549,13 +546,7 @@ mod tests {
         let age_tuple = (today - 30, today + 1);
         let min_msm = 0u32;
         let submit = client
-            .make_submit_request(
-                py,
-                cc.clone_ref(py),
-                asn.clone_ref(py),
-                age_tuple,
-                min_msm,
-            )
+            .make_submit_request(py, cc.clone_ref(py), asn.clone_ref(py), age_tuple, min_msm)
             .unwrap();
         (server, submit, cc, asn, age_tuple, min_msm)
     }


### PR DESCRIPTION
Today, probe_id is just SHA-256 over only the compressed NYM. This commit changes the way it's computed: it is now the SHA-256 over the userauth v1 salt plus the compressed NYM.