### PR TITLE
feat: make digest_point function public for external use

### DIFF
--- a/ooniauth-core/src/submit.rs
+++ b/ooniauth-core/src/submit.rs
@@ -46,7 +46,7 @@ impl SubmitRequest {
     }
 }
 
-fn digest_point(point: RistrettoPoint) -> [u8; 32] {
+pub fn digest_point(point: RistrettoPoint) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(PROBE_ID_SALT);
     hasher.update(point.compress().as_bytes());


### PR DESCRIPTION
This diff makes the `digest_point` function public to be used by dowstream libraries like ooniprobe-rs (https://github.com/ooni/ooniprobe-rs). Works on https://github.com/ooni/userauth/pull/38#issuecomment-4438334351.