### PR TITLE
Expose submit_measurement_hash to Python

### DIFF
--- a/ooniauth-py/ooniauth_py.pyi
+++ b/ooniauth-py/ooniauth_py.pyi
@@ -5,46 +5,72 @@ import builtins
 import typing
 
 __version__: builtins.str
+
 class CredentialError(builtins.Exception):
     r"""
     An authentication error
     """
+
     ...
 
 class DeserializationFailed(builtins.Exception):
     r"""
     An error trying to deserialize a base64-encoded payload
     """
+
     ...
 
 class ProtocolError(builtins.Exception):
     r"""
     An error performing the protocol
     """
+
     ...
 
 class ServerState:
     def __new__(cls) -> ServerState: ...
     @staticmethod
-    def from_creds(public_parameters:str, secret_key:str) -> ServerState:
+    def from_creds(public_parameters: str, secret_key: str) -> ServerState:
         r"""
         Create a new server state from base64-encoded keys
         This is meant to be used by the server, so it can store the keys somewhere and recreate the
         state when needed
         """
+
     def get_secret_key(self) -> str: ...
     def get_public_parameters(self) -> str: ...
-    def handle_registration_request(self, registration_request:str) -> str: ...
+    def handle_registration_request(self, registration_request: str) -> str: ...
     @staticmethod
     def today() -> builtins.int: ...
-    def handle_submit_request(self, nym:str, request:str, probe_cc:str, probe_asn:str, measurement_hash:str, age_range:tuple[builtins.int, builtins.int], min_measurement_count:builtins.int) -> str: ...
-    def handle_submit_request_with_hash(self, nym:str, request:str, probe_cc:str, probe_asn:str, measurement:str, age_range:tuple[builtins.int, builtins.int], min_measurement_count:builtins.int) -> str:
+    def handle_submit_request(
+        self,
+        nym: str,
+        request: str,
+        probe_cc: str,
+        probe_asn: str,
+        measurement_hash: str,
+        age_range: tuple[builtins.int, builtins.int],
+        min_measurement_count: builtins.int,
+    ) -> str: ...
+    def handle_submit_request_with_hash(
+        self,
+        nym: str,
+        request: str,
+        probe_cc: str,
+        probe_asn: str,
+        measurement: str,
+        age_range: tuple[builtins.int, builtins.int],
+        min_measurement_count: builtins.int,
+    ) -> str:
         r"""
         Performs a submission request computing the hash from the input
         measurement. Computes the hash internally using the
         [submit_measurement_hash] function
         """
-    def handle_update_request(self, req:str, old_public_params:str, old_secret_key:str) -> str: ...
+
+    def handle_update_request(
+        self, req: str, old_public_params: str, old_secret_key: str
+    ) -> str: ...
 
 class SubmitRequest:
     @property
@@ -53,33 +79,43 @@ class SubmitRequest:
     def request(self) -> str: ...
 
 class UserState:
-    def __new__(cls, public_params:str) -> UserState: ...
+    def __new__(cls, public_params: str) -> UserState: ...
     def get_credential(self) -> typing.Optional[str]: ...
-    def set_public_params(self, new_public_params:str) -> None: ...
+    def set_public_params(self, new_public_params: str) -> None: ...
     def make_registration_request(self) -> str: ...
-    def handle_registration_response(self, resp:str) -> None:
+    def handle_registration_response(self, resp: str) -> None:
         r"""
         Handle a registration response sent by the server, updating your credentials
-        
+
         Note that this function will only work if you previously called
         `make_registration_request`
         """
-    def make_submit_request(self, probe_cc:str, probe_asn:str, measurement_hash:str, age_range:tuple[builtins.int, builtins.int], min_measurement_count:builtins.int) -> SubmitRequest: ...
-    def handle_submit_response(self, response:str) -> None:
+
+    def make_submit_request(
+        self,
+        probe_cc: str,
+        probe_asn: str,
+        measurement_hash: str,
+        age_range: tuple[builtins.int, builtins.int],
+        min_measurement_count: builtins.int,
+    ) -> SubmitRequest: ...
+    def handle_submit_response(self, response: str) -> None:
         r"""
         Handle a submit response sent by the server, updating your credentials
-        
+
         Note that this function will only work if you previously called
         `make_submit_request`
         """
+
     def make_credential_update_request(self) -> str:
         r"""
         Creates a credential update request to be sent to the server.
         """
-    def handle_credential_update_response(self, resp:str) -> None:
+
+    def handle_credential_update_response(self, resp: str) -> None:
         r"""
         Handles the credential update response sent by the server, updating your credentials.
-        
+
         This function only works if you previosly called `make_credential_update_request`
         """
 
@@ -88,11 +124,10 @@ def get_protocol_version() -> builtins.str:
     Returns the version of the `ooniauth-core`, the actual protocol implementation.
     """
 
-def submit_measurement_hash(measurement:builtins.str) -> builtins.str:
+def submit_measurement_hash(measurement: builtins.str) -> builtins.str:
     r"""
     Hash measurement body for submit proof binding.
-    
+
     Returns a base64-encoded 32-byte hash suitable for use with
     `UserState.make_submit_request` and `ServerState.handle_submit_request`.
     """
-

--- a/ooniauth-py/ooniauth_py.pyi
+++ b/ooniauth-py/ooniauth_py.pyi
@@ -37,19 +37,14 @@ class ServerState:
     def handle_registration_request(self, registration_request:str) -> str: ...
     @staticmethod
     def today() -> builtins.int: ...
-    def handle_submit_request(
-        self,
-        nym: str,
-        request: str,
-        probe_cc: str,
-        probe_asn: str,
-        measurement_hash: str,
-        age_range: tuple[builtins.int, builtins.int],
-        min_measurement_count: builtins.int,
-    ) -> str: ...
-    def handle_update_request(
-        self, req: str, old_public_params: str, old_secret_key: str
-    ) -> str: ...
+    def handle_submit_request(self, nym:str, request:str, probe_cc:str, probe_asn:str, measurement_hash:str, age_range:tuple[builtins.int, builtins.int], min_measurement_count:builtins.int) -> str: ...
+    def handle_submit_request_with_hash(self, nym:str, request:str, probe_cc:str, probe_asn:str, measurement:str, age_range:tuple[builtins.int, builtins.int], min_measurement_count:builtins.int) -> str:
+        r"""
+        Performs a submission request computing the hash from the input
+        measurement. Computes the hash internally using the
+        [submit_measurement_hash] function
+        """
+    def handle_update_request(self, req:str, old_public_params:str, old_secret_key:str) -> str: ...
 
 class SubmitRequest:
     @property
@@ -69,16 +64,8 @@ class UserState:
         Note that this function will only work if you previously called
         `make_registration_request`
         """
-
-    def make_submit_request(
-        self,
-        probe_cc: str,
-        probe_asn: str,
-        measurement_hash: str,
-        age_range: tuple[builtins.int, builtins.int],
-        min_measurement_count: builtins.int,
-    ) -> SubmitRequest: ...
-    def handle_submit_response(self, response: str) -> None:
+    def make_submit_request(self, probe_cc:str, probe_asn:str, measurement_hash:str, age_range:tuple[builtins.int, builtins.int], min_measurement_count:builtins.int) -> SubmitRequest: ...
+    def handle_submit_response(self, response:str) -> None:
         r"""
         Handle a submit response sent by the server, updating your credentials
         
@@ -100,3 +87,12 @@ def get_protocol_version() -> builtins.str:
     r"""
     Returns the version of the `ooniauth-core`, the actual protocol implementation.
     """
+
+def submit_measurement_hash(measurement:builtins.str) -> builtins.str:
+    r"""
+    Hash measurement body for submit proof binding.
+    
+    Returns a base64-encoded 32-byte hash suitable for use with
+    `UserState.make_submit_request` and `ServerState.handle_submit_request`.
+    """
+

--- a/ooniauth-py/ooniauth_py.pyi
+++ b/ooniauth-py/ooniauth_py.pyi
@@ -99,6 +99,19 @@ class UserState:
         age_range: tuple[builtins.int, builtins.int],
         min_measurement_count: builtins.int,
     ) -> SubmitRequest: ...
+    def make_submit_request_with_hash(
+        self,
+        probe_cc: str,
+        probe_asn: str,
+        measurement: str,
+        age_range: tuple[builtins.int, builtins.int],
+        min_measurement_count: builtins.int,
+    ) -> SubmitRequest:
+        r"""
+        Creates a submit request computing the hash from the input measurement.
+        Computes the hash internally using the [submit_measurement_hash] function
+        """
+
     def handle_submit_response(self, response: str) -> None:
         r"""
         Handle a submit response sent by the server, updating your credentials

--- a/ooniauth-py/src/lib.rs
+++ b/ooniauth-py/src/lib.rs
@@ -15,6 +15,7 @@ pyo3_stub_gen::module_variable!("ooniauth-py", "__version__", &str);
 fn ooniauth_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(get_protocol_version, m)?)?;
+    m.add_function(wrap_pyfunction!(submit_measurement_hash, m)?)?;
     m.add_class::<ServerState>()?;
     m.add_class::<UserState>()?;
     m.add_class::<SubmitRequest>()?;

--- a/ooniauth-py/src/protocol.rs
+++ b/ooniauth-py/src/protocol.rs
@@ -310,26 +310,40 @@ impl UserState {
         age_range: (u32, u32),
         min_measurement_count: u32,
     ) -> OoniResult<SubmitRequest> {
-        let probe_cc = probe_cc.to_str(py).expect("unable to get string");
-        let probe_asn = probe_asn.to_str(py).expect("unable to get string");
         let measurement_hash = base64_32_arg(py, &measurement_hash, "measurement_hash")?;
 
-        let mut rng = rand::thread_rng();
-        let ((result, client_state), nym) = self.state.submit_request(
-            &mut rng,
-            probe_cc.into(),
-            probe_asn.into(),
+        self.make_submit_request_impl(
+            py,
+            probe_cc,
+            probe_asn,
             &measurement_hash,
-            age_range.0..age_range.1,
-            min_measurement_count..u32::MAX,
-        )?;
+            age_range,
+            min_measurement_count,
+        )
+    }
 
-        self.submit_client_state = Some(client_state);
+    /// Creates a submit request computing the hash from the input measurement.
+    /// Computes the hash internally using the [submit_measurement_hash] function
+    pub fn make_submit_request_with_hash(
+        &mut self,
+        py: Python<'_>,
+        probe_cc: Py<PyString>,
+        probe_asn: Py<PyString>,
+        measurement: Py<PyString>,
+        age_range: (u32, u32),
+        min_measurement_count: u32,
+    ) -> OoniResult<SubmitRequest> {
+        let measurement_str = py_string_arg(py, &measurement, "measurement")?;
+        let measurement_hash = core_submit_measurement_hash(measurement_str.as_bytes());
 
-        Ok(SubmitRequest {
-            nym: to_pystring(py, &nym),
-            request: to_pystring(py, &result),
-        })
+        self.make_submit_request_impl(
+            py,
+            probe_cc,
+            probe_asn,
+            &measurement_hash,
+            age_range,
+            min_measurement_count,
+        )
     }
 
     /// Handle a submit response sent by the server, updating your credentials
@@ -380,6 +394,39 @@ impl UserState {
         self.state.handle_update_response(update_state, response)?;
 
         Ok(())
+    }
+}
+
+// Methods in this implementation block are not exposed to Python
+impl UserState {
+    fn make_submit_request_impl(
+        &mut self,
+        py: Python<'_>,
+        probe_cc: Py<PyString>,
+        probe_asn: Py<PyString>,
+        measurement_hash: &[u8; 32],
+        age_range: (u32, u32),
+        min_measurement_count: u32,
+    ) -> OoniResult<SubmitRequest> {
+        let probe_cc = py_string_arg(py, &probe_cc, "probe_cc")?;
+        let probe_asn = py_string_arg(py, &probe_asn, "probe_asn")?;
+
+        let mut rng = rand::thread_rng();
+        let ((result, client_state), nym) = self.state.submit_request(
+            &mut rng,
+            probe_cc.into(),
+            probe_asn.into(),
+            measurement_hash,
+            age_range.0..age_range.1,
+            min_measurement_count..u32::MAX,
+        )?;
+
+        self.submit_client_state = Some(client_state);
+
+        Ok(SubmitRequest {
+            nym: to_pystring(py, &nym),
+            request: to_pystring(py, &result),
+        })
     }
 }
 

--- a/ooniauth-py/src/protocol.rs
+++ b/ooniauth-py/src/protocol.rs
@@ -526,6 +526,53 @@ mod tests {
     }
 
     #[test]
+    fn test_submit_with_hash() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let server = crate::ServerState::new();
+            let mut client =
+                crate::UserState::new(py, server.get_public_parameters(py)).unwrap();
+
+            let req = client.make_registration_request(py).unwrap();
+            let reg_response = server.handle_registration_request(py, req).unwrap();
+            client.handle_registration_response(py, reg_response).unwrap();
+
+            let cc: Py<PyString> = PyString::new(py, "VE").into();
+            let asn: Py<PyString> = PyString::new(py, "AS1234").into();
+            let measurement: Py<PyString> = PyString::new(py, "measurement:VE:AS1234").into();
+            let today = ServerState::today();
+            let age_tuple = (today - 30, today + 1);
+            let min_msm = 0u32;
+
+            let submit_req = client
+                .make_submit_request_with_hash(
+                    py,
+                    cc.clone_ref(py),
+                    asn.clone_ref(py),
+                    measurement.clone_ref(py),
+                    age_tuple,
+                    min_msm,
+                )
+                .unwrap();
+
+            let resp = server
+                .handle_submit_request_with_hash(
+                    py,
+                    submit_req.nym,
+                    submit_req.request,
+                    cc,
+                    asn,
+                    measurement,
+                    age_tuple,
+                    min_msm,
+                )
+                .unwrap();
+
+            assert!(client.handle_submit_response(py, resp).is_ok());
+        });
+    }
+
+    #[test]
     fn test_credential_update_simple() {
         pyo3::Python::initialize();
         Python::attach(|py| {

--- a/ooniauth-py/src/protocol.rs
+++ b/ooniauth-py/src/protocol.rs
@@ -2,9 +2,8 @@ use base64::prelude::*;
 use ooniauth_core::registration::open_registration;
 use ooniauth_core::submit::submit;
 use ooniauth_core::update::*;
-use ooniauth_core::{self as ooni, PublicParameters, SecretKey,
-    submit::submit_measurement_hash
-};
+use ooniauth_core::{self as ooni, PublicParameters, SecretKey};
+use ooniauth_core::submit::submit_measurement_hash as core_submit_measurement_hash;
 
 use pyo3::{prelude::*, types::PyString};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyfunction, gen_stub_pymethods};
@@ -45,6 +44,16 @@ fn base64_32_arg<'py>(
 #[pyfunction]
 pub fn get_protocol_version() -> &'static str {
     ooniauth_core::VERSION
+}
+
+/// Hash measurement body for submit proof binding.
+///
+/// Returns a base64-encoded 32-byte hash suitable for use with
+/// `UserState.make_submit_request` and `ServerState.handle_submit_request`.
+#[gen_stub_pyfunction(module = "ooniauth-py")]
+#[pyfunction]
+pub fn submit_measurement_hash(measurement: &str) -> String {
+    BASE64_STANDARD.encode(core_submit_measurement_hash(measurement.as_bytes()))
 }
 
 #[gen_stub_pyclass]
@@ -149,7 +158,7 @@ impl ServerState {
         min_measurement_count: u32,
     ) -> OoniResult<Py<PyString>> {
         let measurement_str = py_string_arg(py, &measurement, "measurement")?;
-        let measurement_hash = submit_measurement_hash(measurement_str.as_bytes());
+        let measurement_hash = core_submit_measurement_hash(measurement_str.as_bytes());
 
         self.handle_submit_request_impl(
             py,
@@ -393,6 +402,15 @@ mod tests {
 
     fn test_measurement_hash(py: Python<'_>, value: u8) -> Py<PyString> {
         PyString::new(py, &BASE64_STANDARD.encode([value; 32])).into()
+    }
+
+    #[test]
+    fn test_submit_measurement_hash_wrapper() {
+        let measurement = b"measurement:US:AS1234";
+        let expected = BASE64_STANDARD.encode(ooniauth_core::submit::submit_measurement_hash(
+            measurement,
+        ));
+        assert_eq!(crate::submit_measurement_hash(std::str::from_utf8(measurement).unwrap()), expected);
     }
 
     #[test]

--- a/ooniauth-py/src/protocol.rs
+++ b/ooniauth-py/src/protocol.rs
@@ -2,7 +2,9 @@ use base64::prelude::*;
 use ooniauth_core::registration::open_registration;
 use ooniauth_core::submit::submit;
 use ooniauth_core::update::*;
-use ooniauth_core::{self as ooni, PublicParameters, SecretKey};
+use ooniauth_core::{self as ooni, PublicParameters, SecretKey,
+    submit::submit_measurement_hash
+};
 
 use pyo3::{prelude::*, types::PyString};
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyfunction, gen_stub_pymethods};
@@ -117,27 +119,48 @@ impl ServerState {
         min_measurement_count: u32,
     ) -> OoniResult<Py<PyString>> {
         // Convert arguments from py types to rust types
-        let nym = base64_32_arg(py, &nym, "nym")?;
         let measurement_hash = base64_32_arg(py, &measurement_hash, "measurement_hash")?;
 
-        let request = from_pystring::<ooniauth_core::submit::SubmitRequest>(py, &request)?;
-        let probe_cc = py_string_arg(py, &probe_cc, "probe_cc")?;
-        let probe_asn = py_string_arg(py, &probe_asn, "probe_asn")?;
-
-        // Handle submission
-        let mut rng = rand::thread_rng();
-        let result = self.state.handle_submit(
-            &mut rng,
+        self.handle_submit_request_impl(
+            py,
+            nym,
             request,
-            &nym,
             probe_cc,
             probe_asn,
             &measurement_hash,
-            age_range.0..age_range.1,
-            min_measurement_count..u32::MAX,
-        )?;
+            age_range,
+            min_measurement_count,
+        )
+    }
 
-        Ok(to_pystring(py, &result))
+    /// Performs a submission request computing the hash from the input
+    /// measurement. Computes the hash internally using the
+    /// [submit_measurement_hash] function
+    #[allow(clippy::too_many_arguments)]
+    fn handle_submit_request_with_hash(
+        &self,
+        py: Python<'_>,
+        nym: Py<PyString>,
+        request: Py<PyString>,
+        probe_cc: Py<PyString>,
+        probe_asn: Py<PyString>,
+        measurement: Py<PyString>,
+        age_range: (u32, u32),
+        min_measurement_count: u32,
+    ) -> OoniResult<Py<PyString>> {
+        let measurement_str = py_string_arg(py, &measurement, "measurement")?;
+        let measurement_hash = submit_measurement_hash(measurement_str.as_bytes());
+
+        self.handle_submit_request_impl(
+            py,
+            nym,
+            request,
+            probe_cc,
+            probe_asn,
+            &measurement_hash,
+            age_range,
+            min_measurement_count,
+        )
     }
 
     fn handle_update_request(
@@ -155,6 +178,42 @@ impl ServerState {
         let resp = self.state.handle_update(&mut rng, req, &old_sk, &old_pp)?;
 
         Ok(to_pystring(py, &resp))
+    }
+}
+
+// Methods in this implementation block are not exposed to Python
+impl ServerState {
+    #[allow(clippy::too_many_arguments)]
+    fn handle_submit_request_impl(
+        &self,
+        py: Python<'_>,
+        nym: Py<PyString>,
+        request: Py<PyString>,
+        probe_cc: Py<PyString>,
+        probe_asn: Py<PyString>,
+        measurement_hash: &[u8; 32],
+        age_range: (u32, u32),
+        min_measurement_count: u32,
+    ) -> OoniResult<Py<PyString>> {
+        let nym = base64_32_arg(py, &nym, "nym")?;
+
+        let request = from_pystring::<ooniauth_core::submit::SubmitRequest>(py, &request)?;
+        let probe_cc = py_string_arg(py, &probe_cc, "probe_cc")?;
+        let probe_asn = py_string_arg(py, &probe_asn, "probe_asn")?;
+
+        let mut rng = rand::thread_rng();
+        let result = self.state.handle_submit(
+            &mut rng,
+            request,
+            &nym,
+            probe_cc,
+            probe_asn,
+            measurement_hash,
+            age_range.0..age_range.1,
+            min_measurement_count..u32::MAX,
+        )?;
+
+        Ok(to_pystring(py, &result))
     }
 }
 


### PR DESCRIPTION
Also implements a variant of `ServerState::handle_submit` that does the hashing internally 

closes #44 