### PR TITLE
New benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "base64",
  "bincode",
  "cmz",
+ "criterion",
  "ooniauth-core",
  "pyo3",
  "pyo3-build-config 0.28.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,12 +14,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -237,6 +253,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +293,18 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -302,6 +345,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -476,6 +525,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -675,6 +733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +859,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +913,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "fnv"
@@ -873,6 +968,35 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "group"
@@ -1010,6 +1134,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "indexmap 2.13.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,12 +1314,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -1187,6 +1353,17 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1235,6 +1412,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1454,15 @@ dependencies = [
  "pyo3",
  "pyo3-build-config 0.26.0",
  "rustc-hash",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1327,6 +1523,7 @@ dependencies = [
  "cmz",
  "criterion",
  "ooniauth-core",
+ "pprof",
  "pyo3",
  "pyo3-build-config 0.28.3",
  "pyo3-stub-gen",
@@ -1537,6 +1734,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1835,28 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "criterion",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1759,6 +2001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +2017,18 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -1809,7 +2072,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1842,6 +2105,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1904,6 +2176,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,6 +2203,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2244,6 +2544,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2572,29 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symbolic-common"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -2294,6 +2629,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "thiserror"
@@ -2532,6 +2880,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2916,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2615,6 +2982,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +3005,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2702,6 +3091,12 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ bincode = "1"
 cmz = "0.2"
 serde = "1.0.219"
 thiserror = "2.0.12"
+criterion = { version = "0.5"}

--- a/README.md
+++ b/README.md
@@ -11,4 +11,12 @@ Open `ios/OoniAuthApp.xcodeproj` in Xcode.
 Criterion benchmark (same flow):
 ```bash
 cargo bench -p ooniauth-core
+cargo bench -p ooniauth_py
 ```
+
+To generate a flamegraph for ooniath_py benchmarks:
+```bash
+cargo bench -p ooniauth_py --bench bench_server  -- --profile-time 5
+```
+
+The resulting report will be stored on `target/criterion/server.handle_submit_request_with_hash/profile/flamegraph.svg`

--- a/ooniauth-core/Cargo.toml
+++ b/ooniauth-core/Cargo.toml
@@ -23,7 +23,7 @@ hex = "0.4"
 tracing = "0.1"
 
 [dev-dependencies]
-criterion = { version = "0.5"}
+criterion = {workspace = true}
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 tracing-forest = "0.1"
 

--- a/ooniauth-core/benches/bench_server.rs
+++ b/ooniauth-core/benches/bench_server.rs
@@ -109,6 +109,7 @@ fn bench_update(c: &mut Criterion) {
 fn bench_hash(c: &mut Criterion) {
     c.bench_function("submit_measurement_hash", |b|{
         b.iter_batched(|| {
+            // Measurement bodies are usually ~1mb
             let bytes = random_megabytes(1);
             bytes
         }, |bytes|{

--- a/ooniauth-core/benches/bench_server.rs
+++ b/ooniauth-core/benches/bench_server.rs
@@ -110,11 +110,9 @@ fn bench_hash(c: &mut Criterion) {
     c.bench_function("submit_measurement_hash", |b|{
         b.iter_batched(|| {
             // Measurement bodies are usually ~1mb
-            let bytes = random_megabytes(1);
-            bytes
+            random_megabytes(1)
         },
-        |bytes| submit_measurement_hash(bytes.as_ref())
-        ,
+        |bytes| submit_measurement_hash(bytes.as_ref()),
         BatchSize::SmallInput);
     });
 

--- a/ooniauth-core/benches/bench_server.rs
+++ b/ooniauth-core/benches/bench_server.rs
@@ -112,9 +112,10 @@ fn bench_hash(c: &mut Criterion) {
             // Measurement bodies are usually ~1mb
             let bytes = random_megabytes(1);
             bytes
-        }, |bytes|{
-            submit_measurement_hash(bytes.as_ref())
-        }, BatchSize::SmallInput);
+        },
+        |bytes| submit_measurement_hash(bytes.as_ref())
+        ,
+        BatchSize::SmallInput);
     });
 
 }

--- a/ooniauth-core/benches/bench_server.rs
+++ b/ooniauth-core/benches/bench_server.rs
@@ -1,7 +1,9 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ooniauth_core::{ServerState, UserState};
+use ooniauth_core::submit::submit_measurement_hash;
 use rand::{rngs::ThreadRng, thread_rng};
 use std::hint::black_box;
+use rand::RngCore;
 
 fn setup() -> (ThreadRng, UserState, ServerState) {
     let mut rng = thread_rng();
@@ -10,6 +12,12 @@ fn setup() -> (ThreadRng, UserState, ServerState) {
     let user = UserState::new(pp);
 
     (rng, user, server)
+}
+
+fn random_megabytes(mb: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; mb * 1024 * 1024];
+    rand::thread_rng().fill_bytes(&mut buf);
+    buf
 }
 
 // For now we will only care about server functions, specially handling submit and
@@ -98,5 +106,17 @@ fn bench_update(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_registration, bench_submit, bench_update);
+fn bench_hash(c: &mut Criterion) {
+    c.bench_function("submit_measurement_hash", |b|{
+        b.iter_batched(|| {
+            let bytes = random_megabytes(1);
+            bytes
+        }, |bytes|{
+            submit_measurement_hash(bytes.as_ref())
+        }, BatchSize::SmallInput);
+    });
+
+}
+
+criterion_group!(benches, bench_registration, bench_submit, bench_update, bench_hash);
 criterion_main!(benches);

--- a/ooniauth-py/Cargo.toml
+++ b/ooniauth-py/Cargo.toml
@@ -28,3 +28,7 @@ criterion = {workspace = true}
 
 [build-dependencies]
 pyo3-build-config = "0.28.3"
+
+[[bench]]
+name = "bench_server"
+harness = false

--- a/ooniauth-py/Cargo.toml
+++ b/ooniauth-py/Cargo.toml
@@ -25,6 +25,7 @@ base64 = "0.22.1"
 
 [dev-dependencies]
 criterion = {workspace = true}
+pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
 
 [build-dependencies]
 pyo3-build-config = "0.28.3"

--- a/ooniauth-py/Cargo.toml
+++ b/ooniauth-py/Cargo.toml
@@ -23,5 +23,8 @@ serde = {workspace = true}
 thiserror = {workspace = true}
 base64 = "0.22.1"
 
+[dev-dependencies]
+criterion = {workspace = true}
+
 [build-dependencies]
 pyo3-build-config = "0.28.3"

--- a/ooniauth-py/benches/bench_server.rs
+++ b/ooniauth-py/benches/bench_server.rs
@@ -1,0 +1,66 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use ooniauth_py::{ServerState, UserState};
+use pyo3::{Py, Python, types::PyString};
+use rand::{distributions::Alphanumeric, Rng};
+
+fn random_ascii_string_mb(mb: usize) -> String {
+    let byte_count = mb * 1024 * 1024;
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(byte_count)
+        .map(char::from)
+        .collect()
+}
+
+fn bench_submit(c: &mut Criterion) {
+    pyo3::Python::initialize();
+    Python::attach(|py| {
+        c.bench_function("server.handle_submit_request_with_hash", |b| {
+            b.iter_batched(|| {
+                let server = ServerState::new();
+                let mut client = UserState::new(py, server.get_public_parameters(py)).unwrap();
+                let req = client.make_registration_request(py).unwrap();
+                let reg_response = server.handle_registration_request(py, req).unwrap();
+                client
+                    .handle_registration_response(py, reg_response)
+                    .unwrap();
+
+                let cc: Py<PyString> = PyString::new(py, "VE").into();
+                let asn: Py<PyString> = PyString::new(py, "AS1234").into();
+                let msm_body = random_ascii_string_mb(1);
+                let measurement: Py<PyString> = PyString::new(py, msm_body.as_str()).into();
+                let today = ServerState::today();
+                let age_tuple = (today - 30, today + 1);
+                let min_msm = 0u32;
+
+                let submit_req = client
+                    .make_submit_request_with_hash(
+                        py,
+                        cc.clone_ref(py),
+                        asn.clone_ref(py),
+                        measurement.clone_ref(py),
+                        age_tuple,
+                        min_msm,
+                    )
+                    .unwrap();
+
+                (server, submit_req, cc, asn, measurement, age_tuple, min_msm)
+            },
+                |(server, submit_req, cc, asn, measurement, age_tuple, min_msm)| {
+                server.handle_submit_request_with_hash(
+                    py,
+                    submit_req.nym,
+                    submit_req.request,
+                    cc,
+                    asn,
+                    measurement,
+                    age_tuple,
+                    min_msm
+                )
+            }, BatchSize::SmallInput);
+        });
+    });
+}
+
+criterion_group!(benches, bench_submit);
+criterion_main!(benches);

--- a/ooniauth-py/benches/bench_server.rs
+++ b/ooniauth-py/benches/bench_server.rs
@@ -2,6 +2,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ooniauth_py::{ServerState, UserState};
 use pyo3::{Py, Python, types::PyString};
 use rand::{distributions::Alphanumeric, Rng};
+use pprof::criterion::{Output, PProfProfiler};
 
 fn random_ascii_string_mb(mb: usize) -> String {
     let byte_count = mb * 1024 * 1024;
@@ -62,5 +63,10 @@ fn bench_submit(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_submit);
+criterion_group!{
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_submit
+}
+
 criterion_main!(benches);

--- a/ooniauth-py/src/protocol.rs
+++ b/ooniauth-py/src/protocol.rs
@@ -91,15 +91,15 @@ impl ServerState {
         })
     }
 
-    fn get_secret_key(&self, py: Python<'_>) -> Py<PyString> {
+    pub fn get_secret_key(&self, py: Python<'_>) -> Py<PyString> {
         to_pystring(py, self.state.secret_key_ref())
     }
 
-    fn get_public_parameters(&self, py: Python<'_>) -> Py<PyString> {
+    pub fn get_public_parameters(&self, py: Python<'_>) -> Py<PyString> {
         to_pystring(py, self.state.public_parameters_ref())
     }
 
-    fn handle_registration_request(
+    pub fn handle_registration_request(
         &self,
         py: Python<'_>,
         registration_request: Py<PyString>,
@@ -111,7 +111,7 @@ impl ServerState {
     }
 
     #[staticmethod]
-    fn today() -> u32 {
+    pub fn today() -> u32 {
         ooni::ServerState::today()
     }
 
@@ -159,7 +159,7 @@ impl ServerState {
     /// measurement. Computes the hash internally using the
     /// [submit_measurement_hash] function.
     #[allow(clippy::too_many_arguments)]
-    fn handle_submit_request_with_hash(
+    pub fn handle_submit_request_with_hash(
         &self,
         py: Python<'_>,
         nym: Py<PyString>,
@@ -460,9 +460,9 @@ impl UserState {
 #[pyclass]
 pub struct SubmitRequest {
     #[pyo3(get)]
-    nym: Py<PyString>,
+    pub nym: Py<PyString>,
     #[pyo3(get)]
-    request: Py<PyString>,
+    pub request: Py<PyString>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds extra benchmarks to the project to have a better understanding of performance bottlenecks. 

Also a flamegraph library is added to have a better understanding of the cost per function call. 

Some of the results we found out the following avg times: 

- verification time (measurement hashing + zkp + Python overhead): 34ms 
- zkp: 13ms
- hashing (1mb worth of data): 1ms 

Here's a screenshot of a generated flamegraph: 
<img width="1625" height="509" alt="image" src="https://github.com/user-attachments/assets/c5ab3f9c-b9a0-4f60-9e3f-02d7a22089da" />

- It seems like the Python bindings are introducing a lot of overhead 
- Most time is still spent on verification 
- No Python-related operations are done during verification or hashing, we could potentially release the GIL during this time to allow true parallel execution (see https://pyo3.rs/v0.29.0/parallelism)

closes #46 